### PR TITLE
Upgrade pillow to fix CVE-2026-25990

### DIFF
--- a/2-apm/requirements.txt
+++ b/2-apm/requirements.txt
@@ -4,7 +4,7 @@ Flask==3.1.1
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
-pillow==11.2.1
+pillow==12.2.0
 qrcode==8.2
 Werkzeug==3.1.3
 qrcode[pil]


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0307ad70-6940-42ff-8242-b0c7c56f8a25","source":"chat","resourceId":"cc74c736-b081-46e1-97a8-b1c9632c1e74","workflowId":"5e801095-08d0-4eab-bab9-313f8958c5a3","codeChangeId":"5e801095-08d0-4eab-bab9-313f8958c5a3","sourceType":"code_security_sca"} -->
## Summary

Code Security (SCA) • [View in Code Security (SCA)](https://zatadog.datadoghq.com/security/code-security/sca?query=status%3AOpen%20library_scope%3AProduction%20advisoryType%3AVulnerability%20baseSeverity%3ACritical&column=score&detection=runtime&order=desc&panel_advisoryId=GHSA-cfh3-3jmp-rvhc&panel_libraryName=pillow&panel_libraryVersion=11.2.1)

Upgrade pillow from 11.2.1 to 12.2.0 to fix a high severity vulnerability (GHSA-cfh3-3jmp-rvhc, CVE-2026-25990) affecting PSD image loading.

## Changes
- Updated pillow version in 2-apm/requirements.txt from 11.2.1 to 12.2.0

## Testing
Verified that the updated version (12.2.0) meets the minimum safe version requirement (12.2.0) specified in the remediation guidelines.

---

PR by Bits - [View session in Datadog](https://zatadog.datadoghq.com/code/cc74c736-b081-46e1-97a8-b1c9632c1e74)